### PR TITLE
Reaction and Emoji Support

### DIFF
--- a/configs/bobbyb.json
+++ b/configs/bobbyb.json
@@ -1,12 +1,13 @@
 {
-    "MESSAGES": [
+    "MESSAGE_EVENTS": [
         {
             "TRIGGERS": [  
                 "bobby b",
                 "bobbyb",
                 "bobby-b",
                 ":crown:"
-            ], 
+            ],
+            "REACTIONS": [], 
             "RESPONSES": [
                 "IS THAT HOW YOU SPEAK TO YOUR KING??",
                 "YOU HEARD THE HAND, THE KING'S TOO FAT FOR HIS ARMOR! GO FIND THE BREASTPLATE STRETCHER! NOW!",
@@ -79,7 +80,10 @@
              ]
         }
     ],
-    "MENTIONS": [
+    "REACTION_EVENTS": [
+        {"TRIGGERS": [], "REACTIONS": [], "RESPONSES": []}
+    ],
+    "MENTION_EVENTS": [
         "IS THAT HOW YOU SPEAK TO YOUR KING??",
         "YOU HEARD THE HAND, THE KING'S TOO FAT FOR HIS ARMOR! GO FIND THE BREASTPLATE STRETCHER! NOW!",
         "THE WHORE IS PREGNANT!",
@@ -149,5 +153,7 @@
         "TAKE SHIP FOR THE FREE CITIES WITH MY HORSE AND MY HAMMER, SPEND MY TIME WARRING AND WHORING, THAT’S WHAT I WAS MADE FOR!",
         "THE SELLSWORD KING, HOW THE SINGERS WOULD LOVE ME!" 
     ],
-    "SCHEDULES": []
+    "SCHEDULE_EVENTS": [ 
+        {"MESSAGES": [], "ARGS": {}}
+    ]
 }

--- a/configs/bobbyb.json
+++ b/configs/bobbyb.json
@@ -1,10 +1,11 @@
 {
     "MESSAGES": [
         {
-            "triggers": [  
+            "TRIGGERS": [  
                 "bobby b",
                 "bobbyb",
-                "bobby-b"
+                "bobby-b",
+                ":crown:"
             ], 
             "RESPONSES": [
                 "IS THAT HOW YOU SPEAK TO YOUR KING??",

--- a/configs/config.template.json
+++ b/configs/config.template.json
@@ -1,12 +1,12 @@
 {
-    "MESSAGES": [
+    "MESSAGE_EVENTS": [
         {"TRIGGERS": [], "REACTIONS": [], "RESPONSES": []}
     ],
-    "REACTIONS": [
+    "REACTION_EVENTS": [
         {"TRIGGERS": [], "REACTIONS": [], "RESPONSES": []}
     ],
-    "SCHEDULES": [
+    "SCHEDULE_EVENTS": [
         {"MESSAGES": [], "ARGS": {}}
     ],
-    "MENTIONS": []
+    "MENTION_EVENTS": []
 }

--- a/configs/config.template.json
+++ b/configs/config.template.json
@@ -1,9 +1,9 @@
 {
     "MESSAGES": [
-        {"TRIGGERS": [], "RESPONSES": []}
+        {"TRIGGERS": [], "REACTIONS": [], "RESPONSES": []}
     ],
     "REACTIONS": [
-        {"TRIGGERS": [], "RESPONSES": []}
+        {"TRIGGERS": [], "REACTIONS": [], "RESPONSES": []}
     ],
     "SCHEDULES": [
         {"MESSAGES": [], "ARGS": {}}

--- a/configs/spiderman.json
+++ b/configs/spiderman.json
@@ -1,14 +1,14 @@
 {
-    "MESSAGES": [
+    "MESSAGE_EVENTS": [
         {"TRIGGERS": [":pizza:"], "REACTIONS": [":pizza:"], "RESPONSES": ["I don't deliver that lol"]}
     ],
-    "REACTIONS": [
+    "REACTION_EVENTS": [
         {"TRIGGERS": [":pizza:"], "REACTIONS": [":100:"], "RESPONSES": ["https://i.kym-cdn.com/entries/icons/original/000/022/537/pizza_tim.png"]}
     ],
-    "SCHEDULES": [
+    "SCHEDULE_EVENTS": [
         {"TRIGGERS": [], "RESPONSES": []}
     ],
-    "MENTIONS": [
+    "MENTION_EVENTS": [
         "It's me, your friendly neighborhood Spiderman!",
         "My Spidey Senses are tingling!",
         "I miss Uncle Ben...",

--- a/configs/spiderman.json
+++ b/configs/spiderman.json
@@ -1,9 +1,9 @@
 {
     "MESSAGES": [
-        {"TRIGGERS": [":pizza:"], "RESPONSES": ["I don't deliver that lol"]}
+        {"TRIGGERS": [":pizza:"], "REACTIONS": [":pizza:"], "RESPONSES": ["I don't deliver that lol"]}
     ],
     "REACTIONS": [
-        {"TRIGGERS": [":pizza:"], "RESPONSES": ["https://i.kym-cdn.com/entries/icons/original/000/022/537/pizza_tim.png"]}
+        {"TRIGGERS": [":pizza:"], "REACTIONS": [":100:"], "RESPONSES": ["https://i.kym-cdn.com/entries/icons/original/000/022/537/pizza_tim.png"]}
     ],
     "SCHEDULES": [
         {"TRIGGERS": [], "RESPONSES": []}

--- a/configs/spiderman.json
+++ b/configs/spiderman.json
@@ -1,12 +1,12 @@
 {
     "MESSAGES": [
-        {"triggers": [], "responses": []}
+        {"TRIGGERS": [":pizza:"], "RESPONSES": ["I don't deliver that lol"]}
     ],
     "REACTIONS": [
-        {"triggers": [], "responses": []}
+        {"TRIGGERS": [], "RESPONSES": []}
     ],
     "SCHEDULES": [
-        {"triggers": [], "responses": []}
+        {"TRIGGERS": [], "RESPONSES": []}
     ],
     "MENTIONS": [
         "It's me, your friendly neighborhood Spiderman!",

--- a/configs/spiderman.json
+++ b/configs/spiderman.json
@@ -3,7 +3,7 @@
         {"TRIGGERS": [":pizza:"], "RESPONSES": ["I don't deliver that lol"]}
     ],
     "REACTIONS": [
-        {"TRIGGERS": [], "RESPONSES": []}
+        {"TRIGGERS": [":pizza:"], "RESPONSES": ["https://i.kym-cdn.com/entries/icons/original/000/022/537/pizza_tim.png"]}
     ],
     "SCHEDULES": [
         {"TRIGGERS": [], "RESPONSES": []}

--- a/discord/discord_bot.py
+++ b/discord/discord_bot.py
@@ -65,9 +65,9 @@ async def on_message(message):
     if message.author not in blocked_users:
         # Check for mentions first, otherwise respond to message content based triggers.
         if client.user.mentioned_in(message):
-            await respond(message, get_random_item(response_config.get("MENTIONS", [])))
+            await respond(message, get_random_item(response_config.get("MENTION_EVENTS", [])))
         else:
-            await respond_from_triggers(message, message.content, response_config.get("MESSAGES", []))
+            await respond_from_triggers(message, message.content, response_config.get("MESSAGE_EVENTS", []))
 
 @client.event
 async def on_reaction_add(reaction, user):
@@ -76,7 +76,7 @@ async def on_reaction_add(reaction, user):
     
     if user not in blocked_users:
         content = emoji.demojize(reaction.emoji, use_aliases=True)
-        await respond_from_triggers(reaction.message, reaction.emoji, response_config.get("REACTIONS", []))
+        await respond_from_triggers(reaction.message, reaction.emoji, response_config.get("REACTION_EVENTS", []))
 
 @client.event
 async def on_guild_join(server):
@@ -89,7 +89,7 @@ async def on_ready():
     logger.info("Bot currently running on {} guild(s)".format(len(client.guilds)))
 
     # Start the scheduler if there are scheduled jobs
-    init_message_scheduler(response_config.get("SCHEDULES", {}), client)
+    init_message_scheduler(response_config.get("SCHEDULE_EVENTS", {}), client)
 
 
 if __name__ == '__main__':

--- a/discord/discord_bot.py
+++ b/discord/discord_bot.py
@@ -35,13 +35,13 @@ except Exception as e:
     logger.exception("Error while instantiating Discord client: {}".format(str(vars(e))))
 
 async def respond(message, response):
-    """ Format an awaitable to send as a response to a message object. """
+    """ Format a response to a message object and yield """
     logger.info("Replied to message of user '{}' in guild '{}' / channel '{}'".format(message.author, message.guild, message.channel))
     msg = response.format(message)
     await message.channel.send(msg)
 
 async def respond_from_triggers(message, content, triggers):
-    """ Search message content according to provided triggers and provide the best response. Returns an awaitable """
+    """ Search message content according to provided triggers and yield the best response"""
 
     # Replace emoji unicode with the CLDR names so that we can properly trigger. 
     # This will safely translate only supported unicode, and leave the rest of the string intact.
@@ -63,7 +63,7 @@ async def on_message(message):
     blocked_users = [ client.user ] 
     
     if message.author not in blocked_users:
-        # Check for mentions first. 
+        # Check for mentions first, otherwise respond to message content based triggers.
         if client.user.mentioned_in(message):
             await respond(message, get_random_item(response_config.get("MENTIONS", [])))
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ typing-extensions==3.7.2
 websockets==6.0
 yarl==1.3.0
 APScheduler==3.6.3
+emoji==0.5.4

--- a/utils/core.py
+++ b/utils/core.py
@@ -8,13 +8,13 @@ import os
 from os.path import join, dirname
 
 def get_random_item(choices):
-    """ Returns random quote from list of choices """
+    """ Returns random quote from list of choices, or None if provided no options. """
     if choices:
         return random.choice(choices)
     return None
     
 def is_keyword_mentioned(text, triggers):
-    """ Checks if configured trigger words to call the bot are present in the message content """
+    """ Checks if configured trigger words to call the bot are present in the text content """
      
     for keyword in triggers:
         # Do a case insensitive search. This should work on regex patterns as well.
@@ -26,7 +26,7 @@ def is_keyword_mentioned(text, triggers):
 def get_trigger_from_content(content, messages_config):
     """ Searches message content and returns a specific trigger configuration if one is found, as defined in the provided config """
 
-    # Check each trigger->response pair
+    # Check each trigger->action pair
     for config in messages_config:
         if is_keyword_mentioned(content, config.get("TRIGGERS", [])):
             return config

--- a/utils/core.py
+++ b/utils/core.py
@@ -7,9 +7,11 @@ import json
 import os
 from os.path import join, dirname
 
-def get_random_quote(responses):
-    """ Returns random quote from list of responses"""
-    return random.choice(responses)
+def get_random_item(choices):
+    """ Returns random quote from list of choices """
+    if choices:
+        return random.choice(choices)
+    return None
     
 def is_keyword_mentioned(text, triggers):
     """ Checks if configured trigger words to call the bot are present in the message content """
@@ -21,13 +23,13 @@ def is_keyword_mentioned(text, triggers):
     
     return False
 
-def generate_message_response(text, messages_config):
-    """ Searches message content and returns a triggered response, if one is needed """
+def get_trigger_from_content(content, messages_config):
+    """ Searches message content and returns a specific trigger configuration if one is found, as defined in the provided config """
 
     # Check each trigger->response pair
     for config in messages_config:
-        if is_keyword_mentioned(text, config.get("TRIGGERS", [])):
-            return get_random_quote(config.get("RESPONSES", []))
+        if is_keyword_mentioned(content, config.get("TRIGGERS", [])):
+            return config
     return None
 
 def get_username(author):

--- a/utils/logging_config.ini
+++ b/utils/logging_config.ini
@@ -15,6 +15,7 @@ handlers=stream_handler
 qualname=discord
 level=DEBUG
 handlers=stream_handler
+propagate=0
 
 [handler_stream_handler]
 class=StreamHandler

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -1,5 +1,5 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from utils.core import get_random_quote
+from utils.core import get_random_item
 import logging
 from logging.config import fileConfig
 
@@ -27,6 +27,6 @@ def init_message_scheduler(jobs, client):
 
     for job in jobs:
         scheduler.add_job(send_scheduled_message,
-                          args=[get_random_quote(job.get("MESSAGES", []))],
+                          args=[get_random_item(job.get("MESSAGES", []))],
                           **job.get("ARGS", dict())
                           )

--- a/utils/scheduler.py
+++ b/utils/scheduler.py
@@ -9,7 +9,7 @@ logger = logging.getLogger('discord')
 # Pass in a configuration and scheduled jobs will be added accordingly
 def init_message_scheduler(jobs, client):
 
-    if not jobs or not len(jobs) or not any("MESSAGES" in job.keys() for job in jobs):
+    if not jobs or not len(jobs) or not any(job.get("MESSAGES") for job in jobs):
         logger.info("No jobs found in provided config.")
         return
 
@@ -26,7 +26,9 @@ def init_message_scheduler(jobs, client):
                     logger.debug('Channel {} ignored due to insufficient access permissions: {}', channel.name, ex)
 
     for job in jobs:
-        scheduler.add_job(send_scheduled_message,
-                          args=[get_random_item(job.get("MESSAGES", []))],
-                          **job.get("ARGS", dict())
-                          )
+        messages = job.get("MESSAGES")
+        if messages:
+            scheduler.add_job(send_scheduled_message,
+                            args=[get_random_item(messages)],
+                            **job.get("ARGS", dict())
+                            )


### PR DESCRIPTION
This pull request features three enhancements, and three bugfixes. In order to best accommodate some of these changes, some minor structural changes were implemented which affect usage of the core utils. 

# Bug Fixes

1. The double logging bug has been addressed and remedied. The issue was simply in the default logging config, which didn't explicitly instruct ```discord``` loggers to not propagate back to ```root```. Because of this messages logged by the ```discord``` logger would be propagated to ```root``` and logged again. Ultimately the entire concept of the logger and how it is configured may need to be reviewed.

2. Keys for sample configs have been update after changes from the scheduling PR.

3. ```get_random_quote``` (renamed to ```get_random_item```) was raising an exception when provided with an empty list. Since being able to provide it the config directly (which is allowed to be empty) is convenient and should be expected on the client layer, I consider this a bug. This now checks that the list is non-empty before choosing a random item, and retruns ```None``` otherwise. 

# Enhancements

1. The bot can now be configured to respond to (as a trigger) and respond with (as a response) emojis. 

This is configured by the implementer in the config file with the standard CLDR names of the emoji, delimited with colons on either side. For instance: ```RESPONSES: ["This is an emoji response :100:"]``` Extended emoji set is supported. This usage is consistent for all emoji related enhancements.

2. The bot can respond to reactions as its own form of trigger, independent from the already defined message content triggers. So for instance, if a message is reacted from any non-blocked user, and that reaction is defined in the config as a supported trigger, it is able to respond in the same way it does for message based triggers. 

This is handled with a new primary key in the config ```REACTIONS``` For instance:

```json
"REACTIONS": [
        {"TRIGGERS": [":100:"],  "RESPONSES": ["Response generated from a :100: reaction"]}
    ]
```
3. The bot can respond to REACTION or MESSAGE triggers with its own reactions. i.e. If a trigger from either of those primary keys is hit, it can choose to react to the message in addition to responding to it. There is no branching in this case, it is allowed to BOTH respond AND react, if both options are provided. Note that just one option is allowed to be provided and is handled safely. This is defined with a new key in the trigger configuration, named ```REACTIONS``` So now a message config can look like this

```json
"MESSAGES": [
        {"TRIGGERS": ["Trigger", "Triggers can have emojis 💯 "],  "REACTIONS": [":thumbsup:"], "RESPONSES": ["Response generated from triggers"]}
    ]
```
And in this case the bot will both send the response AND react with 👍 when a message triggers it. This same format is applied to the ```REACTIONS``` primary key and behaves exactly the same way.

# Side Effects

In order to support improved generality and code reuse, some new helper functions were either defined or had their scope extended in discord_bot.py, and some structural changes were made to the functions in utils.core to make them more general use between different trigger configurations. I believe these changes also make the usage of the core utils clearer in the client layer, but that is open for discussion.

# Considerations

I have some concerns regarding the complexity and clarity of the config file. Not a lot of time was spent trying to get the structure perfect, because we seem to be reaching a point where the json file format is not offering us enough features. This is something I did not choose to address in scope of this PR, but I believe it should be addressed in a refactor effort once the initial bot implementation is feature complete.
